### PR TITLE
Adding new broker logging config support

### DIFF
--- a/src/yacfg/profiles/artemis/2.16.0/_modules/logging_properties/default_user_defined.yaml.jinja2
+++ b/src/yacfg/profiles/artemis/2.16.0/_modules/logging_properties/default_user_defined.yaml.jinja2
@@ -1,0 +1,62 @@
+{% from '_libs/utils.jinja2' import mbool without context %}
+
+ac_logging_properties:
+    {% if log_level_root is defined %}
+  logger_level: '{{ log_level_root }}'
+    {% endif %}
+    {% if log_handlers_root is defined %}
+  logger_handlers: '{{ log_handlers_root }}'
+    {% endif %}
+{% if logging is defined %}
+  {% if logging.loggers is defined %}
+  loggers:
+    {% for logger in logging.loggers %}
+  - {{ logger.name }}
+    {% endfor %}
+
+  logger_properties:
+    {% for logger in logging.loggers %}
+      {% if logger.level is defined %}
+  - {{ logger.name }}.level: '{{ logger.level }}'
+      {% endif %}
+      {% if logger.handlers is defined %}
+  - {{ logger.name }}.handlers: '{{ logger.handlers }}'
+      {% endif %}
+      {% if logger.useParentHandlers is defined %}
+  - {{ logger.name }}.useParentHandlers: '{{ mbool(logger.useParentHandlers) }}'
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+
+  {% if logging.handlers is defined %}
+  handlers:
+    {% for handler in logging.handlers %}
+  - name: '{{ handler.name }}'
+      {% if handler.className is defined %}
+    class_name: '{{ handler.className }}'
+      {% endif %}
+      {% if handler.properties is defined %}
+    properties:
+        {% for prop in handler.properties %}
+    - {{ prop.key }}: '{{ prop.value }}'
+        {% endfor %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+
+  {% if logging.formatters is defined %}
+  formatters:
+    {% for formatter in logging.formatters %}
+  - name: '{{ formatter.name }}'
+      {% if formatter.className is defined %}
+    class_name: '{{ formatter.className }}'
+      {% endif %}
+      {% if formatter.properties is defined %}
+    properties:
+        {% for prop in formatter.properties %}
+    - {{ prop.key }}: '{{ prop.value }}'
+        {% endfor %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% endif %}

--- a/src/yacfg/profiles/artemis/2.16.0/default_with_user_address_settings.yaml.jinja2
+++ b/src/yacfg/profiles/artemis/2.16.0/default_with_user_address_settings.yaml.jinja2
@@ -5,19 +5,6 @@ _defaults:
   broker_home: /opt/artemis-2.16.0
   broker_instance: /opt/artemis-2.16.0-i0
 
-  log_level_all: INFO
-  log_level_server: INFO
-  log_level_journal: INFO
-  log_level_utils: INFO
-  log_level_jms: INFO
-  log_level_integration: INFO
-  log_level_jetty: WARN
-  log_level_audit_base: ERROR
-  log_level_audit_message: ERROR
-  log_level_handler_console: DEBUG
-  log_level_handler_file: DEBUG
-  log_level_handler_audit_file: INFO
-
   user_address_settings:
   - match: activemq.management#
     dead_letter_address: DLQ
@@ -83,7 +70,7 @@ broker_xml:
 {% include 'artemis/2.16.0/_modules/jolokia_access/localhost.yaml.jinja2' %}
 
 # logging.properties
-{% include 'artemis/2.16.0/_modules/logging_properties/default.yaml.jinja2' %}
+{% include 'artemis/2.16.0/_modules/logging_properties/default_user_defined.yaml.jinja2' %}
 
 # login.config
 {% include 'artemis/2.16.0/_modules/login_config/jaas_sufficient.yaml.jinja2' %}

--- a/src/yacfg/templates/artemis/2.16.0/ac.logging.properties.jinja2
+++ b/src/yacfg/templates/artemis/2.16.0/ac.logging.properties.jinja2
@@ -1,0 +1,55 @@
+{% from 'libs/utils.jinja2' import mbool without context %}
+
+{% if ac_logging_properties.loggers is defined %}
+loggers={{ ac_logging_properties.loggers|join(',') }}
+{% endif %}
+
+{% if ac_logging_properties.logger_level is defined %}
+logger.level={{ ac_logging_properties.logger_level|overridevalue('ac_log_level_root') }}
+{% endif -%}
+
+{% if ac_logging_properties.logger_handlers is defined %}
+logger.handlers={{ ac_logging_properties.logger_handlers|overridevalue('ac_log_handlers_root') }}
+{% endif %}
+
+{% for option in ac_logging_properties.logger_properties -%}
+    {%- for key, value in option.items() -%}
+        logger.{{ key }}={{ value|overridevalue(value) }}
+    {% endfor %}
+{% endfor %}
+
+{% if ac_logging_properties.handlers is defined %}
+{% for handler in ac_logging_properties.handlers %}
+{% if handler.class_name is defined %}
+handler.{{ handler.name|overridevalue(handler.name) }}={{ handler.class_name }}
+{% endif %}
+{% if handler.properties is defined %}
+handler.{{ handler.name|overridevalue(handler.name) }}.properties=
+    {{- handler.properties|overridevalue_listmapkeys()|map('list')|sum(start=[])|join(',') }}
+    {% for property in  handler.properties -%}
+        {%- for key, value in property.items() -%}
+            handler.{{ handler.name|overridevalue(handler.name) }}.{{ key|overridevalue(key) }}={{ value|overridevalue(value) }}
+        {% endfor %}
+    {% endfor %}
+{% endif %}
+
+{% endfor -%}
+{% endif %}
+
+{% if ac_logging_properties.formatters is defined %}
+{% for formatter in ac_logging_properties.formatters %}
+{% if formatter.class_name is defined %}
+formatter.{{ formatter.name|overridevalue(formatter.name) }}={{ formatter.class_name }}
+{% endif %}
+{% if formatter.properties is defined %}
+formatter.{{ formatter.name|overridevalue(formatter.name) }}.properties=
+    {{- formatter.properties|overridevalue_listmapkeys()|map('list')|sum(start=[])|join(',') }}
+    {% for property in  formatter.properties -%}
+        {%- for key, value in property.items() -%}
+            formatter.{{ formatter.name|overridevalue(formatter.name) }}.{{ key|overridevalue(key) }}={{ value|overridevalue(value) }}
+        {% endfor %}
+    {% endfor %}
+{% endif %}
+
+{% endfor %}
+{% endif %}

--- a/src/yacfg/templates/artemis/2.16.0/logging.properties.jinja2
+++ b/src/yacfg/templates/artemis/2.16.0/logging.properties.jinja2
@@ -3,6 +3,7 @@
 
 {% include 'libs/licenses/apache-2.0/properties.jinja2' %}
 
+{% if logging_properties is defined %}
 # Additional logger names to configure (root logger is always configured)
 # Root logger option
 loggers={{ logging_properties.loggers|join(',') }}
@@ -47,3 +48,4 @@ formatter.{{ formatter.name }}.properties=
     {% endfor %}
 
 {% endfor %}
+{% endif %}

--- a/src/yacfg/templates/artemis/2.16.0/modules/broker_xml/address_settings.jinja2
+++ b/src/yacfg/templates/artemis/2.16.0/modules/broker_xml/address_settings.jinja2
@@ -4,10 +4,10 @@
             {% for address_setting in broker_xml.address_settings %}
             <address-setting match="{{ address_setting.match }}">
                 {% if address_setting.dead_letter_address is defined %}
-                <dead-letter-address>{{ address_setting.dead_letter_address|overridevalue(address_setting.match + 'dead_letter_address') }}</dead-letter-address>
+                <dead-letter-address>{{ address_setting.dead_letter_address|overridevalue(address_setting.dead_letter_address) }}</dead-letter-address>
                 {% endif %}
                 {% if address_setting.expiry_address is defined %}
-                <expiry-address>{{ address_setting.expiry_address|overridevalue(address_setting.match + 'expiry_address') }}</expiry-address>
+                <expiry-address>{{ address_setting.expiry_address|overridevalue(address_setting.expiry_address) }}</expiry-address>
                 {% endif %}
                 {% if address_setting.redelivery_delay is defined %}
                 <redelivery-delay>{{ address_setting.redelivery_delay }}</redelivery-delay>
@@ -16,13 +16,13 @@
                 <redistribution-delay>{{ address_setting.redistribution_delay }}</redistribution-delay>
                 {% endif %}
                 {% if address_setting.max_size_bytes is defined %}
-                <max-size-bytes>{{ address_setting.max_size_bytes|overridevalue(address_setting.match + 'max_size_bytes') }}</max-size-bytes>
+                <max-size-bytes>{{ address_setting.max_size_bytes|overridevalue(address_setting.max_size_bytes) }}</max-size-bytes>
                 {% endif %}
                 {% if address_setting.message_counter_history_day_limit is defined %}
                 <message-counter-history-day-limit>{{ address_setting.message_counter_history_day_limit }}</message-counter-history-day-limit>
                 {% endif %}
                 {% if address_setting.address_full_policy is defined %}
-                <address-full-policy>{{ address_setting.address_full_policy|overridevalue(address_setting.match + 'address_full_policy') }}</address-full-policy>
+                <address-full-policy>{{ address_setting.address_full_policy|overridevalue(address_setting.address_full_policy) }}</address-full-policy>
                 {% endif %}
                 {% if address_setting.auto_create_queues is defined %}
                 <auto-create-queues>{{ mbool(address_setting.auto_create_queues) }}</auto-create-queues>
@@ -43,10 +43,10 @@
                 <max-size-bytes-reject-threshold>{{ address_setting.max_size_bytes_reject_threshold }}</max-size-bytes-reject-threshold>
                 {% endif %}
                 {% if address_setting.default_address_routing_type is defined %}
-                <default-address-routing-type>{{ address_setting.default_address_routing_type|overridevalue(address_setting.match + 'default_address_routing_type') }}</default-address-routing-type>
+                <default-address-routing-type>{{ address_setting.default_address_routing_type|overridevalue(address_setting.default_address_routing_type) }}</default-address-routing-type>
                 {% endif %}
                 {% if address_setting.config_delete_addresses is defined %}
-                <config-delete-addresses>{{ address_setting.config_delete_addresses|overridevalue(address_setting.match + 'config_delete_addresses') }}</config-delete-addresses>
+                <config-delete-addresses>{{ address_setting.config_delete_addresses|overridevalue(address_setting.config_delete_addresses) }}</config-delete-addresses>
                 {% endif %}
                 {% if address_setting.default_non_destructive is defined %}
                 <default-non-destructive>{{ mbool(address_setting.default_non_destructive) }}</default-non-destructive>
@@ -73,16 +73,16 @@
                 <send-to-dla-on-no-route>{{ mbool(address_setting.send_to_dla_on_no_route) }}</send-to-dla-on-no-route>
                 {% endif %}
                 {% if address_setting.default_last_value_key is defined %}
-                <default-last-value-key>{{ address_setting.default_last_value_key|overridevalue(address_setting.match + 'default_last_value_key') }}</default-last-value-key>
+                <default-last-value-key>{{ address_setting.default_last_value_key|overridevalue(address_setting.default_last_value_key) }}</default-last-value-key>
                 {% endif %}
                 {% if address_setting.slow_consumer_policy is defined %}
-                <slow-consumer-policy>{{ address_setting.slow_consumer_policy|overridevalue(address_setting.match + 'slow_consumer_policy') }}</slow-consumer-policy>
+                <slow-consumer-policy>{{ address_setting.slow_consumer_policy|overridevalue(address_setting.slow_consumer_policy) }}</slow-consumer-policy>
                 {% endif %}
                 {% if address_setting.auto_delete_jms_topics is defined %}
                 <auto-delete-jms-topics>{{ mbool(address_setting.auto_delete_jms_topics) }}</auto-delete-jms-topics>
                 {% endif %}
                 {% if address_setting.default_group_first_key is defined %}
-                <default-group-first-key>{{ address_setting.default_group_first_key|overridevalue(address_setting.match + 'default_group_first_key') }}</default-group-first-key>
+                <default-group-first-key>{{ address_setting.default_group_first_key|overridevalue(address_setting.default_group_first_key) }}</default-group-first-key>
                 {% endif %}
                 {% if address_setting.enable_metrics is defined %}
                 <enable-metrics>{{ mbool(address_setting.enable_metrics) }}</enable-metrics>
@@ -91,7 +91,7 @@
                 <min-expiry-delay>{{ address_setting.min_expiry_delay }}</min-expiry-delay>
                 {% endif %}
                 {% if address_setting.dead_letter_queue_suffix is defined %}
-                <dead-letter-queue-suffix>{{ address_setting.dead_letter_queue_suffix|overridevalue(address_setting.match + 'dead_letter_queue_suffix') }}</dead-letter-queue-suffix>
+                <dead-letter-queue-suffix>{{ address_setting.dead_letter_queue_suffix|overridevalue(address_setting.dead_letter_queue_suffix) }}</dead-letter-queue-suffix>
                 {% endif %}
                 {% if address_setting.default_group_buckets is defined %}
                 <default-group-buckets>{{ address_setting.default_group_buckets }}</default-group-buckets>
@@ -103,7 +103,7 @@
                 <retroactive-message-count>{{ address_setting.retroactive_message_count }}</retroactive-message-count>
                 {% endif %}
                 {% if address_setting.dead_letter_queue_prefix is defined %}
-                <dead-letter-queue-prefix>{{ address_setting.dead_letter_queue_prefix|overridevalue(address_setting.match + 'dead_letter_queue_prefix') }}</dead-letter-queue-prefix>
+                <dead-letter-queue-prefix>{{ address_setting.dead_letter_queue_prefix|overridevalue(address_setting.dead_letter_queue_prefix) }}</dead-letter-queue-prefix>
                 {% endif %}
                 {% if address_setting.default_ring_size is defined %}
                 <default-ring-size>{{ address_setting.default_ring_size }}</default-ring-size>
@@ -151,7 +151,7 @@
                 <max-redelivery-delay>{{ address_setting.max_redelivery_delay }}</max-redelivery-delay>
                 {% endif %}
                 {% if address_setting.default_queue_routing_type is defined %}
-                <default-queue-routing-type>{{ address_setting.default_queue_routing_type|overridevalue(address_setting.match + 'default_queue_routing_type') }}</default-queue-routing-type>
+                <default-queue-routing-type>{{ address_setting.default_queue_routing_type|overridevalue(address_setting.default_queue_routing_type) }}</default-queue-routing-type>
                 {% endif %}
                 {% if address_setting.slow_consumer_check_period is defined %}
                 <slow-consumer-check-period>{{ address_setting.slow_consumer_check_period }}</slow-consumer-check-period>
@@ -160,7 +160,7 @@
                 <slow-consumer-threshold>{{ address_setting.slow_consumer_threshold }}</slow-consumer-threshold>
                 {% endif %}
                 {% if address_setting.config_delete_queues is defined %}
-                <config-delete-queues>{{ address_setting.config_delete_queues|overridevalue(address_setting.match + 'config_delete_queues') }}</config-delete-queues>
+                <config-delete-queues>{{ address_setting.config_delete_queues|overridevalue(address_setting.config_delete_queues) }}</config-delete-queues>
                 {% endif %}
                 {% if address_setting.management_browse_page_size is defined %}
                 <management-browse-page-size>{{ address_setting.management_browse_page_size }}</management-browse-page-size>
@@ -169,13 +169,13 @@
                 <auto-delete-queues>{{ mbool(address_setting.auto_delete_queues) }}</auto-delete-queues>
                 {% endif %}
                 {% if address_setting.expiry_queue_suffix is defined %}
-                <expiry-queue-suffix>{{ address_setting.expiry_queue_suffix|overridevalue(address_setting.match + 'expiry_queue_suffix') }}</expiry-queue-suffix>
+                <expiry-queue-suffix>{{ address_setting.expiry_queue_suffix|overridevalue(address_setting.expiry_queue_suffix) }}</expiry-queue-suffix>
                 {% endif %}
                 {% if address_setting.auto_delete_queues_message_count is defined %}
                 <auto-delete-queues-message-count>{{ address_setting.auto_delete_queues_message_count }}</auto-delete-queues-message-count>
                 {% endif %}
                 {% if address_setting.expiry_queue_prefix is defined %}
-                <expiry-queue-prefix>{{ address_setting.expiry_queue_prefix|overridevalue(address_setting.match + 'expiry_queue_prefix') }}</expiry-queue-prefix>
+                <expiry-queue-prefix>{{ address_setting.expiry_queue_prefix|overridevalue(address_setting.expiry_queue_prefix) }}</expiry-queue-prefix>
                 {% endif %}
                 {% if address_setting.default_purge_on_no_consumers is defined %}
                 <default-purge-on-no-consumers>{{ mbool(address_setting.default_purge_on_no_consumers) }}</default-purge-on-no-consumers>
@@ -184,7 +184,7 @@
                 <default-exclusive-queue>{{ mbool(address_setting.default_exclusive_queue) }}</default-exclusive-queue>
                 {% endif %}
                 {% if address_setting.page_size_bytes is defined %}
-                <page-size-bytes>{{ address_setting.page_size_bytes|overridevalue(address_setting.match + 'page_size_bytes') }}</page-size-bytes>
+                <page-size-bytes>{{ address_setting.page_size_bytes|overridevalue(address_setting.page_size_bytes) }}</page-size-bytes>
                 {% endif %}
             </address-setting>
                 {% if not loop.last %}

--- a/src/yacfg/yacfg.py
+++ b/src/yacfg/yacfg.py
@@ -102,7 +102,7 @@ def generate_core(config_data, tuned_profile=None, template=None,
         :type value_key: str
         :return: str
         """
-        if value_key in extra_properties_data:
+        if extra_properties_data is not None and value_key in extra_properties_data:
             return extra_properties_data[value_key]
         return value
 
@@ -118,8 +118,36 @@ def generate_core(config_data, tuned_profile=None, template=None,
         """
         return value
 
+    def override_value_list_map_keys(value):
+        """
+        Replace keys with overrides if possible
+        in list of maps
+        :param value:
+        :type value: list of dict
+        :return: list of dict
+        """
+        for idx, item in enumerate(value):
+            item = override_value_map_keys(item)
+            value[idx] = item
+        return value
+
+    def override_value_map_keys(value):
+        """
+        Replace keys with overrides if possible
+        :param value:
+        :type value: dict
+        :return: dict
+        """
+        new_map = dict()
+        for key in value.keys():
+            val = value[key]
+            key = override_value(key, key)
+            new_map[key] = val
+        return new_map
+
     # Pass empty filter for performance if an extra_properties_data not defined (no more conditions)
     env.filters['overridevalue'] = override_value if extra_properties_data else empty_filter
+    env.filters['overridevalue_listmapkeys'] = override_value_list_map_keys
 
     template_list = get_main_template_list(env)
     if output_filter:

--- a/tests/extras/results/special_logging_setting_result.yaml
+++ b/tests/extras/results/special_logging_setting_result.yaml
@@ -1,0 +1,26 @@
+
+loggers=org.apache.activemq.jms
+
+logger.level=OFF
+logger.handlers=CONSOLE,FILE
+
+logger.org.apache.activemq.jms.level=OFF
+logger.org.apache.activemq.jms.handlers=FakeHandler
+logger.org.apache.activemq.jms.useParentHandlers=true
+
+handler.YES.properties=level,formatter,ON,fileSize
+handler.YES.level=TRACE
+handler.YES.formatter=OFF
+handler.YES.ON=DEBUG
+handler.YES.fileSize=20m
+
+handler.FakeHandler2=org.logger.fake2.FakeHandler
+
+
+formatter.OFF=org.logger.fake.FakeFormatter
+formatter.OFF.properties=pattern,style
+formatter.OFF.pattern=%d %-5p [%c] %s%E%n
+formatter.OFF.style=normal
+
+formatter.OTHERFORMATTER=org.logger.fake.OtherFormatter
+

--- a/tests/extras/test_broker_special_char.py
+++ b/tests/extras/test_broker_special_char.py
@@ -18,12 +18,12 @@ import os
 
 
 def test_with_special_chars(*_):
-
+    print("tesing 1")
     tune_file = 'extras/tune_files/special_address_setting.yaml'
 
     profile = 'artemis/2.16.0/default_with_user_address_settings.yaml.jinja2'
     tuning_files = [tune_file]
-    extra_props = {'#dead_letter_queue_prefix':'','#config_delete_queues':'OFF'}
+    extra_props = {'uuid1':'','uuid2':'OFF'}
     output = 'etc'
 
     yacfg.generate(
@@ -51,4 +51,50 @@ def test_with_special_chars(*_):
 
     finally:
         file1.close()
+        shutil.rmtree(output)
+
+
+def trim_empty_lines(lines):
+    new_lines = []
+    for l in lines:
+        if len(l.strip()) > 0:
+            new_lines.append(l)
+    return new_lines
+
+
+def test_logging_with_special_chars(*_):
+
+    print("testing 2")
+    tune_file = 'extras/tune_files/special_logging_setting.yaml'
+    result_file = 'extras/results/special_logging_setting_result.yaml'
+
+    profile = 'artemis/2.16.0/default_with_user_address_settings.yaml.jinja2'
+    tuning_files = [tune_file]
+    extra_props = {'ac_log_level_root':'OFF','uniid':'OFF','uniid1':'OFF','uniid2':'ON','uniid3':'OFF','uniid4':'YES'}
+    output = 'etc'
+
+    yacfg.generate(
+        profile=profile,
+        tuning_files_list=tuning_files,
+        extra_properties_data=extra_props,
+        output_path=output
+    )
+
+    logging_properties = output + '/ac.logging.properties'
+    file1 = open(logging_properties, 'r')
+    file2 = open(result_file, 'r')
+    try:
+        lines1 = file1.readlines()
+        lines2 = file2.readlines()
+
+        result1 = trim_empty_lines(lines1)
+        result2 = trim_empty_lines(lines2)
+
+        assert len(result1) == len(result2)
+        length = len(result1)
+        for i in range(length):
+            assert result1[i] == result2[i]
+    finally:
+        file1.close()
+        file2.close()
         shutil.rmtree(output)

--- a/tests/extras/tune_files/special_address_setting.yaml
+++ b/tests/extras/tune_files/special_address_setting.yaml
@@ -18,5 +18,5 @@ log_level_utils: INFO
 user_address_settings:
   - address_full_policy: PAGE
     match: '#'
-    dead_letter_queue_prefix:
-    config_delete_queues: OFF
+    dead_letter_queue_prefix: uuid1
+    config_delete_queues: uuid2

--- a/tests/extras/tune_files/special_logging_setting.yaml
+++ b/tests/extras/tune_files/special_logging_setting.yaml
@@ -1,0 +1,50 @@
+# yacfg tuning file generated from profile artemis/2.16.0/default_with_user_logging.yaml.jinja2
+---
+broker_home: /opt/artemis-2.16.0
+broker_instance: /opt/artemis-2.16.0-i0
+broker_name: amq
+
+log_level_root: OFF
+log_handlers_root: CONSOLE,FILE
+
+logging:
+  loggers:
+  - name: org.apache.activemq.jms
+    level: uniid
+    handlers: FakeHandler
+    useParentHandlers: true
+  handlers:
+  - name: uniid4
+    properties:
+    - key: level
+      value: TRACE
+    - key: formatter
+      value: uniid1
+    - key: uniid2
+      value: DEBUG
+    - key: fileSize
+      value: 20m
+  - name: FakeHandler2
+    className: org.logger.fake2.FakeHandler
+  formatters:
+  - name: uniid3
+    className: org.logger.fake.FakeFormatter
+    properties:
+    - key: pattern
+      value: '%d %-5p [%c] %s%E%n'
+    - key: style
+      value: normal
+  - name: OTHERFORMATTER
+    className: org.logger.fake.OtherFormatter
+user_address_settings:
+  - address_full_policy: PAGE
+    auto_create_addresses: true
+    auto_create_jms_queues: true
+    auto_create_jms_topics: true
+    auto_create_queues: true
+    dead_letter_address: DLQ
+    expiry_address: ExpiryQueue
+    match: '#'
+    max_size_bytes: -1
+    message_counter_history_day_limit: 17
+    redelivery_delay: 0


### PR DESCRIPTION
When using default_with_user_address_settings.yaml.jinja2 profile
one can generate customized logging configurations so that
it only generate what the tune file specified, no more no less.
It can facilitate tools that use it to merge new logging config
into broker existing logging.configuration files.

Fixes #

## Proposed Changes (What, How, and Why)

  -
  -
  -
